### PR TITLE
añadido nueva funcion para poder rellenar AUTH Y PW

### DIFF
--- a/somosioticos_dialogflow.php
+++ b/somosioticos_dialogflow.php
@@ -1,4 +1,7 @@
 <?php
+
+autentificacion();
+
 $usuario_recibido   = $_SERVER['PHP_AUTH_USER'];
 $pass_recibido      = $_SERVER['PHP_AUTH_PW'];
 $inputJSON          = file_get_contents('php://input');
@@ -7,7 +10,6 @@ $respuesta          = "";
 $respuesta_texto    = "";
 $respuesta_cards[]  = array();
 $respuesta_images[] = array();
-header('Content-Type: application/json;charset=utf-8');
 
 /*
 _______  _______  _______ _________ ______  _________ _______
@@ -248,3 +250,14 @@ function enviar_respuestas_rapidas($respuestas, $plataforma)
       ] }' . PHP_EOL;
 
   }
+
+//comprobar autentificación, sino forzarla para logearse
+function autentificacion(){
+    if (!isset($_SERVER['PHP_AUTH_USER'])) {
+        header('WWW-Authenticate: Basic realm="My Realm"');
+        header('HTTP/1.0 401 Unauthorized');
+        echo 'Text to send if user hits Cancel button';
+        exit;
+    }
+  }
+    

--- a/somosioticos_dialogflow.php
+++ b/somosioticos_dialogflow.php
@@ -256,7 +256,7 @@ function autentificacion(){
     if (!isset($_SERVER['PHP_AUTH_USER'])) {
         header('WWW-Authenticate: Basic realm="My Realm"');
         header('HTTP/1.0 401 Unauthorized');
-        echo 'Text to send if user hits Cancel button';
+        echo 'AUTENTIFICACIÓN DENEGADA';
         exit;
     }
   }


### PR DESCRIPTION
A fecha de hoy da error la librería, puede ser por algún cambio que hubo en el servidor con el CGI o alguna actualización de PHP, ya que $_SERVER[PHP_AUTH_USER] y $_SERVER[PHP_AUTH_PW] no existen y rompe con las funciones.

He añadido una función extra para poder forzar la autentificación, y llamándola antes de asignar las variables de $usuario_recibido y $pass_recibido 